### PR TITLE
ci: remove redundant pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install pre-commit
-        run: pip install pre-commit
-      - name: Run pre-commit
-        run: pre-commit run --all-files
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves #14

Removed the `pre-commit` job from CI to avoid duplicating checks (`fmt`, `clippy`, `build`, `test`) that are already handled by separate jobs in the workflow.