### PR TITLE
feat: rename binary from gwt to gwtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "gwt"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "gwtree"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.5.53", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ GWT streamlines this workflow by providing a unified interface for creating, nav
 
 This project is currently under active development.
 
+## Installation
+
+The tool consists of two components:
+- `gwtree` - the compiled binary
+- `gwt` - a shell function that wraps `gwtree`
+
+The shell function is required because changing the current working directory must be done by the shell itself (a subprocess cannot change the parent shell's directory).
+
+### Build
+
+```bash
+cargo build --release
+```
+
+This produces the `gwtree` binary in `target/release/`.
+
+### Shell Integration
+
+Add the following to your shell configuration (e.g., `~/.bashrc` or `~/.zshrc`):
+
+```bash
+# gwt - Git Worktree Management
+gwt() {
+    gwtree "$@"
+}
+```
+
 ## User Manual
 
 ### Configuration


### PR DESCRIPTION
## Summary

- Rename the binary from `gwt` to `gwtree` to allow a shell function named `gwt` to wrap the binary
- Add installation documentation explaining the two-component architecture

## Rationale

Since the tool requires shell integration to change the current working directory (which a subprocess cannot do), we need:
- `gwtree` - the actual binary/executable
- `gwt` - a shell function that wraps `gwtree` and handles directory changes

## Changes

- Updated `Cargo.toml` to set the binary name to `gwtree`
- Added Installation section to README with build and shell integration instructions

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)