### PR TITLE
refactor: Move sub command switch and init into their respective module

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,1 +1,3 @@
 pub mod config;
+pub mod shell;
+pub mod worktree;

--- a/src/command/shell/mod.rs
+++ b/src/command/shell/mod.rs
@@ -1,0 +1,21 @@
+use gwt::generate_init;
+
+pub struct Init {
+    pub shell: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InitCommandError {
+    #[error("{0}")]
+    ShellError(String),
+}
+
+pub fn handle_init_command(cmd: &Init) -> Result<(), InitCommandError> {
+    match generate_init(&cmd.shell) {
+        Ok(s) => {
+            println!("{}", s);
+            Ok(())
+        }
+        Err(e) => Err(InitCommandError::ShellError(e)),
+    }
+}

--- a/src/command/worktree/mod.rs
+++ b/src/command/worktree/mod.rs
@@ -1,0 +1,51 @@
+use crate::config;
+use crate::config::Config;
+use gwt::{WorktreeError, find_worktree_for_branch, list_worktrees};
+
+pub struct Switch {
+    pub branch: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SwitchCommandError {
+    #[error("Setup cancelled. Run gwt again to configure.")]
+    SetupCancelled,
+    #[error("Configuration error: {0}")]
+    ConfigError(#[from] config::ConfigError),
+    #[error("Error ensuring worktree root exists: {0}")]
+    WorktreeRootError(String),
+    #[error("Worktree for branch {0} doesn't exist.")]
+    WorktreeNotFound(String),
+    #[error("Git error: {0}")]
+    GitError(String),
+    #[error("Error listing worktrees: {0}")]
+    ListError(WorktreeError),
+}
+
+pub fn handle_switch_command(cmd: &Switch) -> Result<(), SwitchCommandError> {
+    let config = match Config::init() {
+        Ok(config) => config,
+        Err(config::ConfigError::SetupCancelled) => {
+            return Err(SwitchCommandError::SetupCancelled);
+        }
+        Err(e) => return Err(SwitchCommandError::ConfigError(e)),
+    };
+
+    config
+        .ensure_worktree_root()
+        .map_err(|e| SwitchCommandError::WorktreeRootError(e.to_string()))?;
+
+    match list_worktrees() {
+        Ok(wts) => match find_worktree_for_branch(&wts, &cmd.branch) {
+            Some(w) => {
+                println!("{}", w.path().display());
+                Ok(())
+            }
+            None => Err(SwitchCommandError::WorktreeNotFound(cmd.branch.clone())),
+        },
+        Err(e) => match e {
+            WorktreeError::GitError(s) => Err(SwitchCommandError::GitError(s)),
+            _ => Err(SwitchCommandError::ListError(e)),
+        },
+    }
+}


### PR DESCRIPTION
This PR refactors the codebase to move the `switch` and `init` subcommands into their respective modules, following the same pattern as the existing `config` command.

## Changes
- Created `src/command/worktree/mod.rs` with Switch command handler
- Created `src/command/shell/mod.rs` with Init command handler  
- Updated `src/command/mod.rs` to include new modules
- Refactored `src/main.rs` to delegate to command handlers

## Benefits
- Better code organization and separation of concerns
- Consistent structure with existing Config command module
- Improved maintainability

Fixes #24