### PR TITLE
feat: rename 'switch' subcommand to 'sw' (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `gwtree switch <branch>` now notifies the user via stderr when a new worktree is created. 📢
-- `gwtree switch <branch>` now checks if the current branch matches the requested branch. If so, it prints a warning in yellow and exits with status 1 (to prevent shell cd). ⚠️
-- Implemented `gwtree switch <branch>` command which prints the path of an existing worktree for the specified branch and exits with 0; prints an error and exits 1 if not found. 🔧
-- Updated `gwtree switch <branch>` to create a worktree when missing (under `<worktree_root>/<repo>/<hash>`), and only error when the branch does not exist. 🔧
+- `gwtree sw <branch>` now notifies the user via stderr when a new worktree is created. 📢
+- `gwtree sw <branch>` now checks if the current branch matches the requested branch. If so, it prints a warning in yellow and exits with status 1 (to prevent shell cd). ⚠️
+- Implemented `gwtree sw <branch>` command which prints the path of an existing worktree for the specified branch and exits with 0; prints an error and exits 1 if not found. 🔧
+- Updated `gwtree sw <branch>` to create a worktree when missing (under `<worktree_root>/<repo>/<hash>`), and only error when the branch does not exist. 🔧
 - Implemented `gwtree init <shell>` which emits shell-integration code for `bash`, `zsh`, and `fish` to allow `gwt` wrapper to `cd` into worktrees on success. 🔧
 - Added `make install` command for convenient local installation (macOS/Linux). 📦
 - Implemented `gwtree config view` command which displays the configuration file path and contents with colored output. This allows users to inspect their configuration without triggering an interactive setup process. 🎨
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - Added unit tests for parsing `git worktree list --porcelain` output and branch matching. ✅
 - Added integration tests:
   - Mock-based tests that substitute `git` via `GWT_GIT` env var to assert CLI behavior. ✅
-  - Real `git` repository tests that create branches and worktrees and assert `gwtree switch` behavior. ✅
+  - Real `git` repository tests that create branches and worktrees and assert `gwtree sw` behavior. ✅
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Reload your shell (or open a new terminal) and you're ready to go.
 
 ### Commands
 
-- `gwtree switch <branch>` — If a worktree already exists for `<branch>`, prints the worktree path to stdout and exits 0. If no worktree exists for that branch, creates a new worktree and prints its path to stdout (exit 0). If the branch does not exist, prints an error message to stderr and exits 1.
+- `gwtree sw <branch>` — If a worktree already exists for `<branch>`, prints the worktree path to stdout and exits 0. If no worktree exists for that branch, creates a new worktree and prints its path to stdout (exit 0). If the branch does not exist, prints an error message to stderr and exits 1.
 
 Example (existing worktree):
 
 ```bash
-$ gwt switch feature-branch
+$ gwt sw feature-branch
 /path/to/worktrees/feature-branch
 $ echo $?
 0
@@ -79,7 +79,7 @@ $ echo $?
 Example (missing worktree: created):
 
 ```bash
-$ gwt switch feature-branch
+$ gwt sw feature-branch
 $HOME/.gwt_store/<repo>/<hash>
 $ echo $?
 0
@@ -118,9 +118,9 @@ Bash / Zsh example (what `gwtree init bash` prints):
 
 ```bash
 gwt() {
-  if [ "$1" = "switch" ]; then
+  if [ "$1" = "switch" ] || [ "$1" = "sw" ]; then
     local result
-    result=$(command gwtree switch "${@:2}")
+    result=$(command gwtree sw "${@:2}")
     local exit_code=$?
     if [ $exit_code -eq 0 ]; then
       cd "$result" || return 1
@@ -138,8 +138,8 @@ Fish example (what `gwtree init fish` prints):
 
 ```fish
 function gwt
-  if test "$argv[1]" = "switch"
-    set result (command gwtree switch (echo $argv | sed 's/^switch //'))
+  if test "$argv[1]" = "switch" -o "$argv[1]" = "sw"
+    set result (command gwtree sw $argv[2..-1])
     set exit_code $status
     if test $exit_code -eq 0
       cd "$result"; or return 1

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -19,7 +19,7 @@ pub enum Commands {
     Config(config::ConfigCommands),
 
     /// Switch to an existing worktree for a branch (prints path on success)
-    Switch {
+    Sw {
         /// Branch name to switch to
         branch: String,
     },

--- a/src/command/shell/mod.rs
+++ b/src/command/shell/mod.rs
@@ -8,9 +8,9 @@ pub fn handle(shell: &str) -> Result<()> {
 fn generate_init(shell: &str) -> Result<String> {
     match shell {
         "bash" | "zsh" => Ok(r#"gwt() {
-    if [ "$1" = "switch" ]; then
+    if [ "$1" = "switch" ] || [ "$1" = "sw" ]; then
         local result
-        result=$(command gwtree switch "${@:2}")
+        result=$(command gwtree sw "${@:2}")
         local exit_code=$?
         if [ $exit_code -eq 0 ]; then
             if [ -d "$result" ]; then
@@ -27,8 +27,8 @@ fn generate_init(shell: &str) -> Result<String> {
 "#
         .to_string()),
         "fish" => Ok(r#"function gwt
-    if test "$argv[1]" = "switch"
-        set result (command gwtree switch (echo $argv | sed 's/^switch //'))
+    if test "$argv[1]" = "switch" -o "$argv[1]" = "sw"
+        set result (command gwtree sw $argv[2..-1])
         set exit_code $status
         if test $exit_code -eq 0
             if test -d "$result"
@@ -59,6 +59,7 @@ mod tests {
         let s = generate_init("bash").unwrap();
         assert!(s.contains("gwt() {"));
         assert!(s.contains("command gwtree"));
+        assert!(s.contains(r#"[ "$1" = "switch" ] || [ "$1" = "sw" ]"#));
     }
 
     #[test]
@@ -66,6 +67,15 @@ mod tests {
         let s = generate_init("zsh").unwrap();
         assert!(s.contains("gwt() {"));
         assert!(s.contains("command gwtree"));
+        assert!(s.contains(r#"[ "$1" = "switch" ] || [ "$1" = "sw" ]"#));
+    }
+
+    #[test]
+    fn generate_fish_init_contains_function() {
+        let s = generate_init("fish").unwrap();
+        assert!(s.contains("function gwt"));
+        assert!(s.contains("command gwtree"));
+        assert!(s.contains(r#"test "$argv[1]" = "switch" -o "$argv[1]" = "sw""#));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -179,7 +179,7 @@ mod tests {
         assert!(content.contains("worktree_root = \"/tmp/gwt_test\""));
 
         // Test loading
-        let cmd = crate::command::Commands::Switch {
+        let cmd = crate::command::Commands::Sw {
             branch: "test".to_string(),
         };
         let loaded = load_with_home(&cmd, &home).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ fn main() -> Result<()> {
     let config = config::load(&cli.command)?;
 
     match cli.command {
-        Commands::Config(config_cmd) => command::config::handle(&config, &config_cmd),
-        Commands::Switch { branch } => command::worktree::handle(&config, &branch),
+        Commands::Config(config_command) => command::config::handle(&config, &config_command),
+        Commands::Sw { branch } => command::worktree::handle(&config, &branch),
         Commands::Init { shell } => command::shell::handle(&shell),
     }
 }


### PR DESCRIPTION
This PR renames the 'switch' subcommand to 'sw' to provide a more concise CLI experience. The 'switch' command is no longer available as a first-class command name in the binary, although the shell integration still supports 'switch' as an input for backward compatibility/familiarity while calling 'sw' under the hood.

### Key Changes
- **Rename Subcommand**: Renamed `Switch` to `Sw` in `src/command/mod.rs`.
- **Shell Integration**: Updated `generate_init` in `src/command/shell/mod.rs` to call `gwtree sw` instead of `gwtree switch`. The shell function still intercepts both `switch` and `sw`.
- **Tests**: Updated internal tests in `src/config/mod.rs` and shell integration tests to match the new command name.
- **Documentation**: Updated `README.md` and `CHANGELOG.md` to reflect `sw` as the primary command.

Fixes #34