### PR TITLE
test: improve playground environment with sample git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Improved playground environment by automatically creating a sample git repository (`test_repo`) on startup. 🏗️
 - `gwtree sw <branch>` now notifies the user via stderr when a new worktree is created. 📢
 - `gwtree sw <branch>` now checks if the current branch matches the requested branch. If so, it prints a warning in yellow and exits with status 1 (to prevent shell cd). ⚠️
 - Implemented `gwtree sw <branch>` command which prints the path of an existing worktree for the specified branch and exits with 0; prints an error and exits 1 if not found. 🔧

--- a/Dockerfile.playground
+++ b/Dockerfile.playground
@@ -37,4 +37,11 @@ RUN git config --global user.email "developer@playground.local" \
 # Set up shell integration
 RUN echo 'eval "$(gwtree init bash)"' >> ~/.bashrc
 
+# Create sample git repository
+RUN mkdir test_repo && cd test_repo \
+    && git init -b master \
+    && echo "# Test Repository" > README.md \
+    && git add README.md \
+    && git commit -m "initial commit"
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This PR updates the playground Dockerfile to automatically initialize
a sample git repository ('test_repo') upon container startup. This
provides an immediate environment for users to test 'gwt' commands
without manual setup.

Closes #39
