### PR TITLE
chore: prepare release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-31
+
 ### Added
 
 - Added `gwt rm <branch>` command to remove worktrees by branch name instead of directory paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ Branch feature/my-feature @ Worktree /home/user/.gwt_store/a1b2c3d4e5f6g7h8
 #### `gwt config view`
 Displays the location and current contents of your configuration file. This is useful for verifying where your worktrees are being stored.
 
+---
+
+#### `gwt config setup`
+Interactively sets up or resets your configuration. It will prompt you for the `worktree_root` directory.
+
+---
+
+#### `gwt ls`
+Lists all worktrees in a concise format: `{path} {head} [{branch}]`. For detached worktrees, it only shows the path and the head commit hash.
+
+**Example:**
+```bash
+$ gwt ls
+/home/user/repo 3fdfaf9 [main]
+/home/user/.gwt_store/a1b2c3d4 86ee136 [feature/api]
+```
+
+---
+
 #### `gwtree init <shell>`
 Generates the shell integration code required for the `gwt` wrapper to function. This is typically used once during initial setup in your `.bashrc`, `.zshrc`, or `config.fish`. Supported shells: `bash`, `zsh`, `fish`.
 


### PR DESCRIPTION
## Summary
This PR prepares the repository for the v0.2.0 release.

### Changes:
- Bumps version to `0.2.0` in `Cargo.toml`.
- Updates `CHANGELOG.md` to include the `[0.2.0]` release section with all recent additions and improvements.
- Updates `README.md` to document the new `gwt ls` and `gwt config setup` commands.

## Test plan
- [x] `cargo build` and `cargo test` passed.
- [x] Verified README formatting.