### PR TITLE
Update submodule source to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shared/claude"]
 	path = shared/claude
-	url = git@github.com:troydai/my-claude-settings.git
+	url = https://github.com/troydai/my-claude-settings.git


### PR DESCRIPTION
Changed the shared/claude submodule URL from SSH to HTTPS format to support environments where SSH is not available. This allows the submodule to be initialized and updated in Claude Code cloud environments.