### PR TITLE
feat: add --this flag to rm command for removing current worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,14 @@ $ gwt sw -m
 
 ---
 
-#### `gwt rm <branch> [-b|--delete-branch] [-B|--force-delete-branch]` (Remove)
+#### `gwt rm <branch> [--this] [-b|--delete-branch] [-B|--force-delete-branch] [-y|--yes]` (Remove)
 
 The `rm` (remove) command simplifies worktree removal by allowing you to specify branches instead of directory paths.
 
 - **Branch-Centric Workflow**: Specify the branch name to identify and remove its associated worktree, eliminating the need to remember or look up worktree directory paths.
+- **Remove Current Worktree**: Use `--this` to remove the worktree you're currently in. GWT will automatically detect the branch and switch you to the home worktree before deletion.
 - **Automatic Directory Switching**: If you're currently working inside the worktree being removed, GWT automatically switches you to the main worktree before deletion, preventing errors from deleting your current directory.
-- **Interactive Confirmation**: Prompts for confirmation before removing the worktree to prevent accidental deletions.
+- **Interactive Confirmation**: Prompts for confirmation before removing the worktree to prevent accidental deletions. Use `-y` or `--yes` to skip the confirmation prompt.
 - **Optional Branch Deletion**: Use `-b` or `--delete-branch` to delete the branch after removing the worktree. Use `-B` or `--force-delete-branch` for force deletion (equivalent to `git branch -D`).
 
 **Example:**
@@ -169,9 +170,14 @@ $ gwt rm feature-api-v2
 Remove worktree at '/Users/me/.gwt_store/a1b2c3d4e5f6g7h8' for branch 'feature-api-v2'? [y/N] y
 Worktree for branch 'feature-api-v2' removed.
 
-# Remove a worktree and delete the branch
-$ gwt rm feature-api-v2 -b
+# Remove the current worktree (automatically detects the branch)
+$ gwt rm --this
 Remove worktree at '/Users/me/.gwt_store/a1b2c3d4e5f6g7h8' for branch 'feature-api-v2'? [y/N] y
+Worktree for branch 'feature-api-v2' removed.
+# You are now in the home worktree
+
+# Remove a worktree and delete the branch (skip confirmation)
+$ gwt rm feature-api-v2 -B -y
 Worktree for branch 'feature-api-v2' removed.
 Branch 'feature-api-v2' deleted.
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -54,7 +54,12 @@ pub enum Commands {
     /// Remove a worktree by branch name
     Rm {
         /// Branch name of the worktree to remove
-        branch: String,
+        #[arg(required_unless_present = "this", conflicts_with = "this")]
+        branch: Option<String>,
+
+        /// Remove the current worktree (switches to home first)
+        #[arg(long = "this")]
+        this: bool,
 
         /// Delete the branch after removing the worktree
         #[arg(short = 'b', long = "delete-branch")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,14 @@ fn main() -> Result<()> {
         } => command::worktree::switch(&config, branch.as_deref(), create, main, remote.as_deref()),
         Commands::Rm {
             branch,
+            this,
             delete_branch,
             force_delete_branch,
             skip_confirmation,
         } => command::worktree::remove(
             &config,
-            &branch,
+            branch.as_deref(),
+            this,
             delete_branch,
             force_delete_branch,
             skip_confirmation,


### PR DESCRIPTION
## Summary

- Add `--this` flag to `gwt rm` command that removes the current worktree
- Automatically detects the branch of the current worktree
- Switches to the home repository before deletion when used

This allows the following convenient usage:

```bash
~/.gwt_store/11bf7ca9a9b5863d issue-82
$ gwt rm --this

~/code/github.com/troydai/gwt main
```

Which is equivalent to:
```bash
~/.gwt_store/11bf7ca9a9b5863d issue-82
$ gwt home

~/code/github.com/troydai/gwt main
$ gwt rm -B -y issue-82
```

Closes #84

## Test plan

- [x] Verify `gwt rm --help` shows the new `--this` flag
- [x] Verify `--this` and branch argument are mutually exclusive
- [x] Verify branch is required when `--this` is not used
- [x] Verify `--this` correctly detects current worktree branch
- [x] Verify worktree is removed and home path is output
- [x] All 66 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)